### PR TITLE
Bugfix related to Unpacker crashing at jsrv3

### DIFF
--- a/Unpacker2/Unpacker2.cc
+++ b/Unpacker2/Unpacker2.cc
@@ -221,7 +221,7 @@ void Unpacker2::DistributeEventsSingleStep(string filename) {
       // read out the header of the event into hdr structure
       pHdr = (UInt_t*) &hdr;
       file->read((char *) (pHdr), getHdrSize());
-      
+
       eventSize = (size_t) getFullSize();
       
       if(debugMode == true)
@@ -351,7 +351,7 @@ void Unpacker2::DistributeEventsSingleStep(string filename) {
                   prev_coarse = coarse;
                   
                   if (useTDCcorrection == true &&
-                      TDCcorrections[channel + channelOffset]) {
+                      TDCcorrections[channel + channelOffset] != nullptr) {
                     fine = TDCcorrections[channel + channelOffset]->GetBinContent(fine + 1);
                   }
                   else {
@@ -536,6 +536,8 @@ bool Unpacker2::loadTDCcalibFile(const char* calibFile){
       if(tmp){
         TDCcorrections[i] = dynamic_cast<TH1F*>(tmp->Clone(tmp->GetName()));
         TDCcorrections[i]->SetDirectory(dir);
+      }else{
+        TDCcorrections[i] = nullptr;
       }
 
     }


### PR DESCRIPTION
For some reason, the uninitialized TH1F* pointers seemed to pass the
if(TDCcorrection[...]) condition, leading to a segmentation fault
on certain platforms. Explicitly using nullptr solves this problem.

We need to incorporate it quickly as this bug prevents using the new Framework version at our main server.