### PR TITLE
Using output path and updated TDC correcionts readout to Unpacker2D

### DIFF
--- a/include/Unpacker2.h
+++ b/include/Unpacker2.h
@@ -70,7 +70,10 @@ protected:
   std::string fTDCCalibFile;
   std::map<UInt_t, UInt_t> tdc_offsets;
   int highest_channel_number = -1;
+
   TH1F** TDCcorrections = nullptr;
+  std::map<int, TH1F*> fTDCCorrections;
+
   bool useTDCcorrection = false;
   TH1F* TOTcalibHist = nullptr;
   int fRefChannelOffset;

--- a/src/Unpacker2D.cc
+++ b/src/Unpacker2D.cc
@@ -305,9 +305,11 @@ void Unpacker2D::DistributeEventsSingleStep()
 
   if (file->is_open())
   {
-
     EventIII* eventIII = new EventIII();
-    string newFileName = fileName + ".root";
+
+    // open a new file
+    string newFileName = fOutputFilePath + fInputFile + ".root";
+
     TFile* newFile = new TFile(newFileName.c_str(), "RECREATE");
     TTree* newTree = new TTree("T", "Tree");
     newTree->Branch("eventIII", "EventIII", &eventIII, 64000, 99);

--- a/src/Unpacker2D.cc
+++ b/src/Unpacker2D.cc
@@ -72,7 +72,14 @@ void Unpacker2D::BuildEvent(EventIII* e, std::map<UInt_t, std::vector<UInt_t>>* 
 
     if (useTDCcorrection)
     {
-      time = (coarse * kCoarseConstant) - ((TDCcorrections[ref_it->first]->GetBinContent(fine + 1)));
+      double correction = 0.0;
+      auto search = fTDCCorrections.find(ref_it->first);
+      if (search != fTDCCorrections.end())
+      {
+        correction = fTDCCorrections.at(ref_it->first)->GetBinContent(fine + 1);
+      }
+      time = (coarse * kCoarseConstant) - correction;
+      // time = (coarse * kCoarseConstant) - ((TDCcorrections[ref_it->first]->GetBinContent(fine + 1)));
     }
     else
     {
@@ -98,7 +105,14 @@ void Unpacker2D::BuildEvent(EventIII* e, std::map<UInt_t, std::vector<UInt_t>>* 
 
       if (useTDCcorrection)
       {
-        time = coarse * kCoarseConstant - ((TDCcorrections[m_it->first]->GetBinContent(fine + 1)));
+        double correction = 0.0;
+        auto search = fTDCCorrections.find(m_it->first);
+        if (search != fTDCCorrections.end())
+        {
+          correction = fTDCCorrections.at(m_it->first)->GetBinContent(fine + 1);
+        }
+        time = (coarse * kCoarseConstant) - correction;
+        // time = coarse * kCoarseConstant - ((TDCcorrections[m_it->first]->GetBinContent(fine + 1)));
       }
       else
       {
@@ -239,26 +253,28 @@ void Unpacker2D::UnpackSingleStep(string inputFile, string inputPath, string out
   DistributeEventsSingleStep();
 }
 
-bool Unpacker2D::loadTDCcalibFile(const char* calibFile)
+bool Unpacker2D::loadTDCcalibFile(const char* calibFileName)
 {
-  TFile* f = new TFile(calibFile, "READ");
+  TFile* file = new TFile(calibFileName, "READ");
   TDirectory* dir = gDirectory->GetDirectory("Rint:/");
 
-  if (f->IsOpen())
+  if (file->IsOpen())
   {
-    TDCcorrections = new TH1F*[highest_channel_number];
+    // TDCcorrections = new TH1F*[highest_channel_number];
     for (int i = kModularOffset; i < highest_channel_number; i++)
     {
-      TH1F* tmp = dynamic_cast<TH1F*>(f->Get(Form("correction%d", i)));
+      TH1F* tmp = dynamic_cast<TH1F*>(file->Get(Form("correction%d", i)));
       if (tmp)
       {
-        TDCcorrections[i] = dynamic_cast<TH1F*>(tmp->Clone(tmp->GetName()));
-        TDCcorrections[i]->SetDirectory(dir);
+        fTDCCorrections[i] = dynamic_cast<TH1F*>(tmp->Clone(tmp->GetName()));
+        fTDCCorrections[i]->SetDirectory(dir);
+        // TDCcorrections[i] = dynamic_cast<TH1F*>(tmp->Clone(tmp->GetName()));
+        // TDCcorrections[i]->SetDirectory(dir);
       }
-      else
-      {
-        TDCcorrections[i] = nullptr;
-      }
+      // else
+      // {
+      //   TDCcorrections[i] = nullptr;
+      // }
     }
 
     if (debugMode)
@@ -270,15 +286,15 @@ bool Unpacker2D::loadTDCcalibFile(const char* calibFile)
   {
     if (debugMode)
     {
-      cerr << "The TDC calibration file " << calibFile << " could not be properly opened." << endl;
+      cerr << "The TDC calibration file " << calibFileName << " could not be properly opened." << endl;
       cerr << "TDC nonlinearity correction will not be used!" << endl;
     }
-    f->Close();
-    delete f;
+    file->Close();
+    delete file;
     return false;
   }
-  f->Close();
-  delete f;
+  file->Close();
+  delete file;
   return true;
 }
 

--- a/src/Unpacker2D.cc
+++ b/src/Unpacker2D.cc
@@ -79,7 +79,6 @@ void Unpacker2D::BuildEvent(EventIII* e, std::map<UInt_t, std::vector<UInt_t>>* 
         correction = fTDCCorrections.at(ref_it->first)->GetBinContent(fine + 1);
       }
       time = (coarse * kCoarseConstant) - correction;
-      // time = (coarse * kCoarseConstant) - ((TDCcorrections[ref_it->first]->GetBinContent(fine + 1)));
     }
     else
     {
@@ -112,7 +111,6 @@ void Unpacker2D::BuildEvent(EventIII* e, std::map<UInt_t, std::vector<UInt_t>>* 
           correction = fTDCCorrections.at(m_it->first)->GetBinContent(fine + 1);
         }
         time = (coarse * kCoarseConstant) - correction;
-        // time = coarse * kCoarseConstant - ((TDCcorrections[m_it->first]->GetBinContent(fine + 1)));
       }
       else
       {
@@ -260,7 +258,6 @@ bool Unpacker2D::loadTDCcalibFile(const char* calibFileName)
 
   if (file->IsOpen())
   {
-    // TDCcorrections = new TH1F*[highest_channel_number];
     for (int i = kModularOffset; i < highest_channel_number; i++)
     {
       TH1F* tmp = dynamic_cast<TH1F*>(file->Get(Form("correction%d", i)));
@@ -268,13 +265,7 @@ bool Unpacker2D::loadTDCcalibFile(const char* calibFileName)
       {
         fTDCCorrections[i] = dynamic_cast<TH1F*>(tmp->Clone(tmp->GetName()));
         fTDCCorrections[i]->SetDirectory(dir);
-        // TDCcorrections[i] = dynamic_cast<TH1F*>(tmp->Clone(tmp->GetName()));
-        // TDCcorrections[i]->SetDirectory(dir);
       }
-      // else
-      // {
-      //   TDCcorrections[i] = nullptr;
-      // }
     }
 
     if (debugMode)


### PR DESCRIPTION
I have noticed that in Unpacker2D class we forgot to use file output path, as it is done in Unpacker2.cpp

Also adding updated method of reading TDC corrections from calibration file, as the previous one generated null pointer errors. 