### PR TITLE
Fix warning about ambiguity from the result of tellg()

### DIFF
--- a/src/Unpacker2D.cc
+++ b/src/Unpacker2D.cc
@@ -449,7 +449,7 @@ void Unpacker2D::DistributeEventsSingleStep()
               else
               {
                 // regular ending
-                file->seekg(file->tellg() - 4);
+                file->seekg(static_cast<unsigned int>(file->tellg()) - 4);
                 queueSize--;
                 break;
               }


### PR DESCRIPTION
Explicitly casting the output of @tellg()@ to unsigned integer removes  the following compilation warning

<pre>
/home/alek/dev/framework-bin/Unpacker2/src/Unpacker2D.cc: In member function ‘void Unpacker2D::DistributeEventsSingleStep()’:
/home/alek/dev/framework-bin/Unpacker2/src/Unpacker2D.cc:452:45: warning: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second:
  452 |                 file->seekg(file->tellg() - 4);
      |                                             ^
In file included from /usr/include/c++/10/bits/char_traits.h:40,
                 from /usr/include/c++/10/string:40,
                 from /home/alek/Programy/root-system-6-24-02/include/TSchemaHelper.h:17,
                 from /home/alek/Programy/root-system-6-24-02/include/TGenericClassInfo.h:21,
                 from /home/alek/Programy/root-system-6-24-02/include/Rtypes.h:191,
                 from /home/alek/Programy/root-system-6-24-02/include/TObject.h:17,
                 from /home/alek/dev/framework-bin/Unpacker2/include/Unpacker2D.h:4,
                 from /home/alek/dev/framework-bin/Unpacker2/src/Unpacker2D.cc:1:
/usr/include/c++/10/bits/postypes.h:198:7: note: candidate 1: ‘std::fpos<_StateT> std::fpos<_StateT>::operator-(std::streamoff) const [with _StateT = __mbstate_t; std::streamoff = long int]’
  198 |       operator-(streamoff __off) const
      |       ^~~~~~~~
/home/alek/dev/framework-bin/Unpacker2/src/Unpacker2D.cc:452:45: note: candidate 2: ‘operator-(std::streamoff {aka long int}, int)’ (built-in)
  452 |                 file->seekg(file->tellg() - 4);
      |                                             ^
</pre>